### PR TITLE
feat(app): echo-25 Add Docker support for frontend and backend services

### DIFF
--- a/api/bruno/environments/docker.bru
+++ b/api/bruno/environments/docker.bru
@@ -1,0 +1,3 @@
+vars {
+  URL: https://backend.rhea.orb.local/api
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,25 @@
 services:
-  server:
-    build: .
+  backend:
+    build:
+      context: .
+      dockerfile: ./internal/Dockerfile
     ports:
       - "8000:8000"
+
+    networks:
+      - rhea-network
+
+  frontend:
+    build:
+      context: ./web
+      dockerfile: ./Dockerfile
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+    networks:
+      - rhea-network
+
+networks:
+  rhea-network:
+    driver: bridge

--- a/internal/Dockerfile
+++ b/internal/Dockerfile
@@ -8,6 +8,9 @@ RUN go mod download
 
 COPY . ./
 
+# Copy swagger docs from the parent context
+COPY api/swagger ./api/swagger
+
 RUN CGO_ENABLED=0 GOOS=linux go build -C ./internal -o /rhea
 
 CMD ["/rhea"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,27 @@
+# Build stage
+FROM node:20-alpine as builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm i
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+
+# Copy built assets from builder stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Add dockerfile to internal and web folders, and update docker-compose to support docker compose up command

Closes: echo-25
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Docker support for both frontend and backend services, allowing the app to run with a single docker-compose command.

- **Dependencies**
  - Added Dockerfiles for backend and frontend.
  - Updated docker-compose.yaml to build and run both services together.

<!-- End of auto-generated description by cubic. -->

