### PR TITLE
feat(app): rhea-2 Added & updated basic containerization

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,96 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+.project
+.settings
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Go build artifacts
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+/vendor/
+dist/
+build/
+
+# Go module cache
+.mod_cache
+
+# Go coverage
+*.cover
+*.coverprofile
+coverage.html
+coverage.out
+
+# Air live reload tool
+.air.toml
+tmp/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+logs/
+
+# Testing
+*_test.go
+testdata/
+
+# Documentation
+README.md
+CHANGELOG.md
+docs/
+*.md
+
+# Docker files (avoid recursive copying)
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Development tools
+Makefile
+.golangci.yml
+.golangci.yaml
+
+# Database files (if any)
+*.db
+*.sqlite
+*.sqlite3
+
+# Temporary files
+tmp/
+temp/
+.tmp
+
+# Bruno API testing (development only)
+api/bruno/
+
+# Atlas migration tool (if not needed in container)
+atlas.hcl
+
+# Any local configuration
+config.local.*
+settings.local.*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
 
   frontend:
     build:
-      context: ./web
+      context: ./frontend
       dockerfile: ./Dockerfile
     ports:
-      - "3000:80"
+      - "3000:3000"
     depends_on:
       - backend
     networks:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,107 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build outputs
+dist
+build
+.vite
+.next
+
+# Development files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Testing
+coverage
+.nyc_output
+.coverage
+
+# Storybook
+storybook-static
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# ESLint cache
+.eslintcache
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# vitest cache
+.vitest
+
+# Documentation
+README.md
+CHANGELOG.md
+docs/
+
+# Docker files (avoid recursive copying)
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Temporary files
+tmp/
+temp/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
added a dockerfile to /frontend and added .dockerignores to both sub-directories

Closes: rhea-2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Containerized the frontend and added .dockerignore files to shrink build contexts and speed up Docker builds. Updates docker-compose to build from ./frontend and expose the dev server on port 3000, addressing RHEA-2 (Containerize).

- **New Features**
  - Frontend Dockerfile (Node 20-alpine); installs with npm ci and runs the dev server on 0.0.0.0:3000.
  - Added .dockerignore to frontend and backend to exclude dev artifacts, VCS/IDE files, logs, docs, and env files.
  - docker-compose now builds from ./frontend and maps 3000:3000 (was 3000:80).

<!-- End of auto-generated description by cubic. -->

